### PR TITLE
FIX: Delete button has bad position in Firefox.

### DIFF
--- a/_attachments/work.js
+++ b/_attachments/work.js
@@ -201,7 +201,7 @@
       doc.addClass("edit");
       top.css("width",doc.first().outerWidth()+"px");
 	  if(version != "original") {
-		top.prepend('<span class="button delete"></span>');
+		top.find(".relative-wrapper").prepend('<span class="button delete"></span>');
 		top.find(".delete").on("click", clickDeleteVersion);
 	  }
     }


### PR DESCRIPTION
Occurs in GNU/Linux Ubuntu 12.04, Firefox 29.0:
The button was showing up in the top left corner of the page instead of top left corner of the translation.
Its position in the DOM is anyway better regarding the rest of the elements.

This was not occurring inside Chrome (Chromium Version 34.0.1847.116)
