### PR TITLE
FIX: Remove the "null" line in dropdown languages in concordance page

### DIFF
--- a/couchdb/views/languages/map.js
+++ b/couchdb/views/languages/map.js
@@ -1,6 +1,10 @@
 function(o) {
-  emit(o.language);
-  for each (t in o.translations) {
-    emit(t.language);
+  if (o.language) {
+    emit(o.language);
+    if (o.translations) {
+      for each (t in o.translations) {
+	emit(t.language);
+      }
+    }
   }
 }


### PR DESCRIPTION
Introduced by the copyright report documents.
